### PR TITLE
Fix closable scan modal for iOS

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -103,6 +103,7 @@
 @property (nonatomic, retain) UIView * reticleView;
 // unsafe_unretained is equivalent to assign - used to prevent retain cycles in the property below
 @property (nonatomic, unsafe_unretained) id orientationDelegate;
+@property (nonatomic, getter=isModalInPresentation) BOOL modalInPresentation;
 
 - (id)initWithProcessor:(CDVbcsProcessor*)processor alternateOverlay:(NSString *)alternateXib;
 - (void)startCapturing;
@@ -351,6 +352,10 @@ parentViewController:(UIViewController*)parentViewController
     self.viewController = [[CDVbcsViewController alloc] initWithProcessor: self alternateOverlay:self.alternateXib];
     // here we set the orientation delegate to the MainViewController of the app (orientation controlled in the Project Settings)
     self.viewController.orientationDelegate = self.plugin.viewController;
+    
+    if (@available(iOS 13, *)) {
+        self.viewController.modalInPresentation = YES;
+    }
 
     // delayed [self openDialog];
     [self performSelector:@selector(openDialog) withObject:nil afterDelay:1];


### PR DESCRIPTION
This fix, prevents accidental dismissal of the scanning modal on iOS 13 and later.

Changes:

- I added modalInPresentation property to CDVbcsViewController to control modal dismissal behavior
- I implemented an iOS 13+ check before setting modalInPresentation = YES, ensuring backwards compatibility

This fix prevents users from accidentally swiping down to close the scanner before completing a scan.